### PR TITLE
Add module sync actions

### DIFF
--- a/.github/workflows/submoduleNotifyParent.yml
+++ b/.github/workflows/submoduleNotifyParent.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with: 
-          repository: org/parent_repository
+          repository: osu-atri/osu-dictionary
           token: ${{ secrets.PRIVATE_TOKEN_GITHUB }}
           submodules: true
 

--- a/.github/workflows/submoduleNotifyParent.yml
+++ b/.github/workflows/submoduleNotifyParent.yml
@@ -1,0 +1,29 @@
+name: 'Submodule Notify Parent'
+
+on:
+  push:
+    branches:
+      - main    
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  notify:
+    name: 'Submodule Notify Parent'
+    runs-on: ubuntu-latest
+
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Github REST API Call
+      env:
+        CI_TOKEN: ${{ secrets.CI_TOKEN }}
+        PARENT_REPO: osu-atri/osu-dictionary
+        PARENT_BRANCH: moduleUpdate
+        WORKFLOW_ID: <9999999>
+      run: |
+        curl -fL --retry 3 -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ env.CI_TOKEN }}" https://api.github.com/repos/${{ env.PARENT_REPO }}/actions/workflows/${{ env.WORKFLOW_ID }}/dispatches -d '{"ref":"${{ env.PARENT_BRANCH }}"}'

--- a/.github/workflows/submoduleNotifyParent.yml
+++ b/.github/workflows/submoduleNotifyParent.yml
@@ -1,3 +1,6 @@
+# NOTE: This workflow is not available, as I have no access to the full repository settings to store my Fine-grained personal access tokens.
+
+
 name: 'Submodule Notify Parent'
 
 on:

--- a/.github/workflows/submoduleNotifyParent.yml
+++ b/.github/workflows/submoduleNotifyParent.yml
@@ -1,32 +1,30 @@
-# NOTE: This workflow is not available, as I have no access to the full repository settings to store my Fine-grained personal access tokens.
-
-
-name: 'Submodule Notify Parent'
+name: Send submodule updates to parent repo
 
 on:
   push:
-    branches:
-      - main    
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+    branches: 
+      - main
 
 jobs:
-  notify:
-    name: 'Submodule Notify Parent'
+  update:
     runs-on: ubuntu-latest
 
-    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
-    defaults:
-      run:
-        shell: bash
-
     steps:
-    - name: Github REST API Call
-      env:
-        CI_TOKEN: ${{ secrets.CI_TOKEN }}
-        PARENT_REPO: osu-atri/osu-dictionary
-        PARENT_BRANCH: moduleUpdate
-        WORKFLOW_ID: <9999999>
-      run: |
-        curl -fL --retry 3 -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ env.CI_TOKEN }}" https://api.github.com/repos/${{ env.PARENT_REPO }}/actions/workflows/${{ env.WORKFLOW_ID }}/dispatches -d '{"ref":"${{ env.PARENT_BRANCH }}"}'
+      - uses: actions/checkout@v2
+        with: 
+          repository: org/parent_repository
+          token: ${{ secrets.PRIVATE_TOKEN_GITHUB }}
+          submodules: true
+
+      - name: Pull & update submodules recursively
+        run: |
+          git submodule update --init --recursive
+          git submodule update --recursive --remote
+
+      - name: Commit
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions - update submodules"
+          git add --all
+          git commit -m "Update submodules" || echo "No changes to commit"
+          git push

--- a/.github/workflows/submoduleNotifyParent.yml
+++ b/.github/workflows/submoduleNotifyParent.yml
@@ -21,10 +21,21 @@ jobs:
           git submodule update --init --recursive
           git submodule update --recursive --remote
 
+      - name: Install GitHub CLI
+        run: sudo apt-get install gh
+
+      - name: Authenticate GitHub CLI
+        run: gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+
       - name: Commit
         run: |
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions - update submodules"
+          git checkout -b update-submodules
           git add --all
           git commit -m "Update submodules" || echo "No changes to commit"
-          git push
+          git push origin update-submodules
+
+      - name: Create Pull Request
+        run: |
+          gh pr create --title "Update submodules" --body "This PR updates the submodules." --base main --head update-submodules


### PR DESCRIPTION
Well Github Actions can only be triggered on main branch, merging actions to main for testing.
Repository secret has added so token can be passed securely.

I have created a backup branch of main called 'main-backup' if anything goes wrong.