### PR TITLE
Add permissions to Actions

### DIFF
--- a/.github/workflows/submoduleNotifyParent.yml
+++ b/.github/workflows/submoduleNotifyParent.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Make this fast.

Pinging @CloneWith for repo settings: wondering if you can change the `Workflow permissions` settings under [this](https://github.com/osu-atri/lazer-wiki/settings/actions) site? Change it to "Read and write permissions" if possible. 

This PR is aiming to fix permission issues, if this PR doesn't do its trick, change that setting should help.