### PR TITLE
Fix for rejecting updates

### DIFF
--- a/.github/workflows/submoduleNotifyParent.yml
+++ b/.github/workflows/submoduleNotifyParent.yml
@@ -38,6 +38,7 @@ jobs:
           git checkout -b update-submodules
           git add --all
           git commit -m "Update submodules" || echo "No changes to commit"
+          git pull origin main --rebase
           git push origin update-submodules
 
       - name: Create Pull Request


### PR DESCRIPTION
Failed to push refs since no `git pull` is being executed.